### PR TITLE
improve CPU and memory in Vagrantfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,11 @@
+# General
+.vagrant/
+.DS_Store
+
+# Log files (if you are creating logs in debug mode, uncomment this)
+# *.logs
+
+*.retry
 credentials/
-cluster.retry
 roles/debug
 debug.yml
-.DS_Store
-.vagrant
-debug.retry

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,7 +11,8 @@ Vagrant.configure(2) do |config|
     n = 10 + i
     s.vm.network "private_network", ip: "192.168.56.#{n}"
     s.vm.provider "virtualbox" do |v|
-        v.memory = 2048
+        v.cpus = 2
+        v.memory = 3096
     end
     end
 end


### PR DESCRIPTION
```
v.cpus = 1
v.memory = 2048
```
It may cause the api server to crash due to virtual machine configuration.

So I improve CPU and memory in Vagrantfile.
```
v.cpus = 2
v.memory = 3096
```
