### PR TITLE
fix scale when master not in 'kube-node' group

### DIFF
--- a/scale.yml
+++ b/scale.yml
@@ -1,5 +1,12 @@
 ---
 
+##We still have to gather facts about our masters and etcd nodes
+- hosts: kube-master:kube-node:etcd
+  any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
+  vars:
+    ansible_ssh_pipelining: true
+  gather_facts: true
+
 - hosts: kube-node
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   roles:


### PR DESCRIPTION
when master node not in kube-node group, run `scale.yaml` will throw 

```
FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'ansible.vars.hostvars.HostVarsVars object' has no attribute 'ansible_default_ipv4'\n\nThe error appears to have been in '/root/workspace/k8s/kubeadm-ansible/roles/base/prepare/tasks/etchosts.yml': line 5, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Hosts | populate inventory into hosts file\n  ^ here\n"}
```

In `roles/base/prepare/tasks/etchosts.yml`, I found this code.

```yaml
- name: Hosts | populate inventory into hosts file
  blockinfile:
    dest: /etc/hosts
    block: |-
      {% for item in (groups['kube-master'] + groups['kube-node'] +groups['etcd']|default([]))|unique -%}{% if k8s_interface is defined %}{{hostvars[item]['ansible_'+k8s_interface].ipv4.address}}{% else %}{{hostvars[item]['ip']|default(hostvars[item]['ansible_default_ipv4']['address'])}}{% endif %} {{ item }} {{ item }}.{{ dns_domain }}
      {% endfor %}
    state: present
    create: yes
    backup: yes
    marker: "# Ansible inventory hosts {mark}"
```

It need gather `kube-master` and `etcd`'s fact. So we still have to gather facts about our masters and etcd nodes