### PR TITLE
fix 'ensure docker-ce repo' missing proxy config

### DIFF
--- a/roles/base/docker/tasks/main.yml
+++ b/roles/base/docker/tasks/main.yml
@@ -18,6 +18,10 @@
 
 - name: Ensure docker-ce repo
   command: yum-config-manager --add-repo {{aliyun_docker_yum_repo}} && yum makecache fast
+  environment:
+    http_proxy: "{{ http_proxy| default ('') }}"
+    https_proxy: "{{ https_proxy| default ('') }}"
+    no_proxy: "{{ no_proxy| default ('') }}"
   tags:
   - docker
 


### PR DESCRIPTION
添加阿里源需要公网访问，对于通过代理访问公网的服务器，需要设置代理环境变量